### PR TITLE
Fix level for last cell of pre-tiled images

### DIFF
--- a/controllers/ImageController.php
+++ b/controllers/ImageController.php
@@ -839,6 +839,7 @@ class UniversalViewer_ImageController extends Omeka_Controller_AbstractActionCon
                         // Level is found.
                         $isLevelFound = true;
                         // Cells are 0-based.
+                        $level = $level - 1;
                         $cellX = $countX - 1;
                         $cellY = $countY - 1;
                         break;


### PR DESCRIPTION
Last cell was incorrectly loading tile from next zoom level when using pre-generated tiles.