### PR TITLE
Fix last cell tile level for pre-generated tiles

### DIFF
--- a/controllers/ImageController.php
+++ b/controllers/ImageController.php
@@ -804,7 +804,7 @@ class UniversalViewer_ImageController extends Omeka_Controller_AbstractActionCon
             // If level is set, count is not set and useless.
             $level = isset($level) ? $level : 0;
             $count = isset($count) ? $count : 0;
-            while ($factor / 2 <= $total) {
+            while ($factor / 2 < $total) {
                 // This allows to determine the level for normal regions.
                 if ($factor < $count) {
                     $level++;


### PR DESCRIPTION
This one I am more confident of.

For images where the maxSize is exactly equal to a 2^n factor, the code was adding an extra level to the squaleFactors array. This caused the level for the last cell to be incorrectly one higher than it should have been. 

Changing the line to read `while ($factor / 2 < $total)` fixes that calculation error in all cases.