### PR TITLE
Replace universalviewer_iiif_max_size

### DIFF
--- a/views/admin/plugins/universal-viewer-config-form.php
+++ b/views/admin/plugins/universal-viewer-config-form.php
@@ -229,11 +229,11 @@ $elements = get_table_options('Element', null, array(
     </div>
     <div class="field">
         <div class="two columns alpha">
-            <?php echo $this->formLabel('universalviewer_iiif_max_size',
+            <?php echo $this->formLabel('universalviewer_max_dynamic_size',
                 __('Max dynamic size for images')); ?>
         </div>
         <div class="inputs five columns omega">
-            <?php echo $this->formText('universalviewer_iiif_max_size', get_option('universalviewer_iiif_max_size'), null); ?>
+            <?php echo $this->formText('universalviewer_max_dynamic_size', get_option('universalviewer_max_dynamic_size'), null); ?>
             <p class="explanation">
                 <?php echo __('Set the maximum size in bytes for the dynamic processing of images.'); ?>
                 <?php echo __('Beyond this limit, the plugin will require a tiled image, for example made with the plugin OpenLayers Zoom.'); ?>


### PR DESCRIPTION
It looks like the `universalviewer_iiif_max_size` options isn't being used anywhere but the configuration form.  It's not being saved in the database and it doesn't appear to be taking effect anywhere.  I think this should be changed to `universalviewer_max_dynamic_size`, which is referenced in `UniversalViewerPlugin.php` and `controllers/ImageController.php`.