### PR TITLE
Fix bug introduced in commit 47f611b

### DIFF
--- a/views/helpers/IiifManifest.php
+++ b/views/helpers/IiifManifest.php
@@ -282,7 +282,7 @@ class UniversalViewer_View_Helper_IiifManifest extends Zend_View_Helper_Abstract
                     'metadata' => $fileMetadata,
                 );
 
-                $mediaType = $media->mediaType();
+                $mediaType = $file->mime_type;
                 switch ($mediaType) {
                     case '':
                         break;


### PR DESCRIPTION
Commit 47f611b changed line 285 to read "$mediaType = $media->mediaType();". $media is not defined, which was causing a fatal error:

PHP Notice:  Undefined variable: media in /var/www/html/example-site/plugins/UniversalViewer/views/helpers/IiifManifest.php on line 285
PHP Fatal error:  Call to a member function mediaType() on a non-object in /var/www/html/example-site/plugins/UniversalViewer/views/helpers/IiifManifest.php on line 285

Changing line 285 to "$mediaType = $file->mime_type;", as $mediaType is defined elsewhere in the code, fixed the error.